### PR TITLE
fix: 禁止按钮文本被选中

### DIFF
--- a/students.html
+++ b/students.html
@@ -15,6 +15,11 @@
     button {
       font-size: 2rem;
       padding: 1rem 2rem;
+      /* 新增代码：禁止文本选中 */
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
     }
     #result {
       font-size: 2rem;


### PR DESCRIPTION
## 修改说明
- 为按钮添加 `user-select: none` 属性，修复文本选中问题，改善使用体验。  
- 关联 Issue：Closes #113 